### PR TITLE
temp fix client crash when logout in naxx

### DIFF
--- a/optional/LogoutCrashNaxx/ElunaScripts/NaxxKick.lua
+++ b/optional/LogoutCrashNaxx/ElunaScripts/NaxxKick.lua
@@ -1,0 +1,12 @@
+-- Based on the -Day36512- script for -ZhengPeiRu21/mod-individual-progression-
+
+local NaxxKick = {}
+
+function NaxxKick.OnLogin(event, player)
+    local mapId = player:GetMapId()
+	if mapId == 533 then
+		player:Teleport(0, 3082.6, -3725.78, 132.41, 0)
+	end
+end
+
+RegisterPlayerEvent(3, NaxxKick.OnLogin)

--- a/optional/LogoutCrashNaxx/Modules/mod-naxxramas-logout-teleport/conf/conf.sh.dist
+++ b/optional/LogoutCrashNaxx/Modules/mod-naxxramas-logout-teleport/conf/conf.sh.dist
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/optional/LogoutCrashNaxx/Modules/mod-naxxramas-logout-teleport/include.sh
+++ b/optional/LogoutCrashNaxx/Modules/mod-naxxramas-logout-teleport/include.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+MOD_NAXXRAMAS_LOGOUT_TELEPORT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/" && pwd )"
+
+source $MOD_NAXXRAMAS_LOGOUT_TELEPORT_ROOT"/conf/conf.sh.dist"
+
+if [ -f $MOD_NAXXRAMAS_LOGOUT_TELEPORT_ROOT"/conf/conf.sh" ]; then
+    source $MOD_NAXXRAMAS_LOGOUT_TELEPORT_ROOT"/conf/conf.sh"
+fi

--- a/optional/LogoutCrashNaxx/Modules/mod-naxxramas-logout-teleport/src/mod_naxxramas_logout_teleport.cpp
+++ b/optional/LogoutCrashNaxx/Modules/mod-naxxramas-logout-teleport/src/mod_naxxramas_logout_teleport.cpp
@@ -1,0 +1,23 @@
+#include "ScriptMgr.h"
+#include "Player.h"
+#include "Map.h"
+#include "WorldSession.h"
+
+class NaxxramasLogoutTeleport : public PlayerScript
+{
+	public:
+		NaxxramasLogoutTeleport() : PlayerScript("NaxxramasLogoutTeleport") { }
+
+		void OnLogin(Player* player) override
+		{
+			if (player->GetMapId() == 533)
+			{
+				player->TeleportTo(0, 3082.641602f, -3725.781250f, 132.418884f, 0.002488f);
+			}
+		}
+};
+
+void AddSC_mod_naxxramas_logout_teleport()
+{
+    new NaxxramasLogoutTeleport();
+}

--- a/optional/LogoutCrashNaxx/Modules/mod-naxxramas-logout-teleport/src/mod_naxxramas_logout_teleport_loader.cpp
+++ b/optional/LogoutCrashNaxx/Modules/mod-naxxramas-logout-teleport/src/mod_naxxramas_logout_teleport_loader.cpp
@@ -1,0 +1,6 @@
+void AddSC_mod_naxxramas_logout_teleport();
+
+void Addmod_naxxramas_logout_teleportScripts()
+{
+    AddSC_mod_naxxramas_logout_teleport();
+}

--- a/optional/LogoutCrashNaxx/README.md
+++ b/optional/LogoutCrashNaxx/README.md
@@ -1,0 +1,10 @@
+# Optional files
+* `LogoutCrashNaxx` if a player logout in Naxx Vanilla and try to relog, client crash occured
+
+## LogoutCrashNaxx
+This folder contains:
+* `Modules/mod-naxxramas-logout-teleport`
+* `ElunaScripts/NaxxKick.lua`
+
+Use the module OR the Eluna script. Choose one, not both.
+This mod acts as a temporary solution. If the player is in naxx on log in, it'll teleport them right outside the raid. Player may have to attempt logging in twice.

--- a/optional/README_optional.md
+++ b/optional/README_optional.md
@@ -1,6 +1,14 @@
 # Optional files
+* `LogoutCrashNaxx` if a player logout in Naxx Vanilla and try to relog, client crash occured, this is a sort of fix
 * `PlaguewoodHub` contains a map edit to restore the original Plaguewood teleporter hub
 
+## LogoutCrashNaxx
+This folder contains:
+* `Modules/mod-naxxramas-logout-teleport`
+* `ElunaScripts/NaxxKick.lua`
+
+Use the module OR the Eluna script. Choose one, not both.
+This mod acts as a temporary solution. If the player is in naxx on log in, it'll teleport them right outside the raid. Player may have to attempt logging in twice.
 
 ## PlaguewoodHub
 this folder contains:


### PR DESCRIPTION
## Changes Proposed:
- Temp fix to prevent game client crash, teleport player outside naxx if logout inside

## Issues Addressed:
- [Issue 43](https://github.com/sogladev/mod-vanilla-naxxramas/issues/43): Client crash when logout in Naxx

## SOURCE:
[valsan-azerty-boi/mod-vanilla-naxxramas/tree/fix/crash-logout-naxx](https://github.com/valsan-azerty-boi/mod-vanilla-naxxramas/tree/fix/crash-logout-naxx)

## Tests Performed:
- Build OK
- In game tests OK

## How to Test the Changes:
1. Logout in Naxx
2. Re login the character
3. Crash client but the character is teleported outside Naxx
4. Re login the character
5. No crash happened now
