### PR TITLE
fix crash on login: move cast entry flag 29296 to only be used when completing entrance flag

### DIFF
--- a/src/Naxxramas/scripts/instance_naxxramas.cpp
+++ b/src/Naxxramas/scripts/instance_naxxramas.cpp
@@ -1482,7 +1482,6 @@ public:
             return;
 
         // Cast on player Naxxramas Entry Flag Trigger DND - Classic (spellID: 29296)
-        player->CastSpell(player, 29296, true);
         if (player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) != QUEST_STATUS_REWARDED)
         {
             // Mark player as having entered
@@ -1490,6 +1489,8 @@ public:
             player->AddQuest(quest, nullptr);
             player->CompleteQuest(NAXX40_ENTRANCE_FLAG);
             player->RewardQuest(quest, 0, player, false, false);
+            // Cast on player Naxxramas Entry Flag Trigger DND - Classic (spellID: 29296)
+            player->CastSpell(player, 29296, true); // for visual effect only, possible crash if cast on login
         }
     }
 };


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Only cast 29296 when completing the entry flag quest, this only occurs when entering from Stratholme to Naxxramas for the first time.

Casting 29296 on map enter sometimes causes a crash on login. According to triggered spellDBC 29294  this visual effect only happens when completing the flag quest.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/sogladev/mod-vanilla-naxxramas/issues/43

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
29296 aura that in 2s triggers 29294
spell dbc 29294
```
ID - 29294 Naxxramas Entry Flag Effect DND
=================================================
Category = 0, SpellIconID = 1, activeIconID = 0, SpellVisual = (4060,0), SpellPriority = 0
Family SPELLFAMILY_GENERIC, flag [0] 0x00000000 [1] 0x00000000 [2] 0x00000000

SpellSchoolMask = 1 (SPELL_SCHOOL_MASK_NORMAL)
DamageClass = 0 (SPELL_DAMAGE_CLASS_NONE)
PreventionType = 0 (SPELL_PREVENTION_TYPE_NONE)
=================================================
Attributes: 0x00000100 (SPELL_ATTR0_DO_NOT_LOG)
AttributesEx1: 0x10000000 (SPELL_ATTR1_NO_AURA_ICON)
AttributesEx2: 0x00000004 (SPELL_ATTR2_IGNORE_LINE_OF_SIGHT)
=================================================
Spell Level = 0, base 0, max 0, maxTarget 0

Category = 0
DispelType = 0 (DISPEL_NONE)
Mechanic = 0 (MECHANIC_NONE)
SpellRange: (Id 4) "Medium Range":
    MinRange = 0, MinRangeFriendly = 0
    MaxRange = 30, MaxRangeFriendly = 30

CastingTime (Id 1) = 0.00

Interrupt Flags: 0x00000000, AuraIF 0x00000000, ChannelIF 0x00000000
Chance = 101, charges - 0
=================================================
Effect 0: Id 16 (SPELL_EFFECT_QUEST_COMPLETE)
BasePoints = 0
Targets (1, 0) (TARGET_UNIT_CASTER, NO_TARGET)
EffectMiscValueA = 9378

Effect 1:  NO EFFECT
```

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
setup: raid with 2 characters inside crash

- logout
- login


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
