### PR TITLE
Update boss_sapphiron_40.cpp

### DIFF
--- a/src/Naxxramas/scripts/boss_sapphiron_40.cpp
+++ b/src/Naxxramas/scripts/boss_sapphiron_40.cpp
@@ -114,11 +114,14 @@ public:
 
         void InitializeAI() override
         {
-            me->SummonGameObject(GO_SAPPHIRON_BIRTH, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), 0, 0, 0, 0, 0, 0);
-            me->SetVisible(false);
-            me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
-            me->SetReactState(REACT_PASSIVE);
-            ScriptedAI::InitializeAI();
+            if (pInstance->GetBossState(BOSS_SAPPHIRON) != DONE)
+            {
+                me->SummonGameObject(GO_SAPPHIRON_BIRTH, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), 0, 0, 0, 0, 0, 0);
+                me->SetVisible(false);
+                me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+                me->SetReactState(REACT_PASSIVE);
+                ScriptedAI::InitializeAI();
+            }
         }
 
         bool IsInRoom()


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- only show birth animation if the boss hasn't been killed yet.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested this with Individual Progression, not with this module.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. kill Sapphiron, logout
2. log back in, the birth animation should not play again
