### PR TITLE
fix: Naxx teleporter requirements

### DIFF
--- a/src/Naxxramas/scripts/custom_gameobjects_40.cpp
+++ b/src/Naxxramas/scripts/custom_gameobjects_40.cpp
@@ -41,7 +41,7 @@ public:
         {
             player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
 
-			if (isAttuned(player) || !sVanillaNaxxramas->requireAttunement)
+            if (isAttuned(player) || !sVanillaNaxxramas->requireAttunement)
                 player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
         }
         return true;

--- a/src/Naxxramas/scripts/custom_gameobjects_40.cpp
+++ b/src/Naxxramas/scripts/custom_gameobjects_40.cpp
@@ -37,7 +37,7 @@ public:
 
     bool OnGossipHello(Player* player, GameObject* /*go*/) override
     {
-        if ((!sVanillaNaxxramas->requireNaxxStrath || player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_REWARDED) && player->GetLevel() <= 70)
+        if ((!sVanillaNaxxramas->requireNaxxStrath || player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_REWARDED))
         {
             player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
 

--- a/src/Naxxramas/scripts/custom_gameobjects_40.cpp
+++ b/src/Naxxramas/scripts/custom_gameobjects_40.cpp
@@ -46,7 +46,6 @@ public:
         }
         return true;
     }
-
 };
 
 void AddSC_custom_gameobjects_40()

--- a/src/Naxxramas/scripts/custom_gameobjects_40.cpp
+++ b/src/Naxxramas/scripts/custom_gameobjects_40.cpp
@@ -40,11 +40,9 @@ public:
         if ((!sVanillaNaxxramas->requireNaxxStrath || player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_REWARDED) && player->GetLevel() <= 70)
         {
             player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
-			
-			if (isAttuned(player) || !sVanillaNaxxramas->requireAttunement )
-			{
+
+			if (isAttuned(player) || !sVanillaNaxxramas->requireAttunement)
                 player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
-			}
         }
         return true;
     }

--- a/src/Naxxramas/scripts/custom_gameobjects_40.cpp
+++ b/src/Naxxramas/scripts/custom_gameobjects_40.cpp
@@ -37,14 +37,18 @@ public:
 
     bool OnGossipHello(Player* player, GameObject* /*go*/) override
     {
-        if ((!sVanillaNaxxramas->requireNaxxStrath || player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_REWARDED)
-            && (!sVanillaNaxxramas->requireAttunement || isAttuned(player)))
+        if ((!sVanillaNaxxramas->requireNaxxStrath || player->GetQuestStatus(NAXX40_ENTRANCE_FLAG) == QUEST_STATUS_REWARDED) && player->GetLevel() <= 70)
         {
             player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
-            player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
+			
+			if (isAttuned(player) || !sVanillaNaxxramas->requireAttunement )
+			{
+                player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
+			}
         }
         return true;
     }
+
 };
 
 void AddSC_custom_gameobjects_40()


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- first set instance difficulty, afterwards check attunement

There was a problem when trying to enter with a group that wasn't fully attuned.
It was possible to end up in wotlk 10man normal mode.
This happened when the player clicking the entry crystal was not the first player in the group.
I believe when clicking the crystal the first player was checked, 
found out he wasn't attuned, then the raid was set to wotlk 10man normal, but was not teleported.
Then when the player that did click the crystal was checked, he was found to be attuned, but because the raid difficulty was already set to wotlk 10man normal for the group, this player ended up in wotlk 10man normal.

And I don't see a level check, it was possible to enter naxx40 at level 71+
but maybe this was on purpose.



## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested this with Individual Progression

