### PR TITLE
fix Naxxramas Worshipper - Widow's Embrace

### DIFF
--- a/data/sql/db-world/base/naxx40_creatures.sql
+++ b/data/sql/db-world/base/naxx40_creatures.sql
@@ -4934,6 +4934,18 @@ INSERT INTO `creature_template_resistance` (`Resistance`, `CreatureID`, `School`
 (5,    16157,   2), (5,    16157,   3), (5,    16157,   4), (5,    16157,   5), (5,    16157,   6),
 (5,    351015,  2), (5,    351015,  3), (5,    351015,  4), (5,    351015,  5), (5,    351015,  6);
 
+-- Naxxramas Worshipper
+DELETE FROM `creature_template_spell` WHERE `CreatureID` = 351081;
+INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES (351081, 3, 28732, 12340);
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceEntry` = 28732;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, 
+`ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
+(13, 1, 28732, 0, 0, 31, 0, 3, 15953, 0, 0, 0, 0, '', ''),
+(13, 1, 28732, 0, 0, 36, 0, 0, 0, 0, 0, 0, 0, '', ''),
+(13, 1, 28732, 0, 1, 31, 0, 3, 351007, 0, 0, 0, 0, '', ''),
+(13, 1, 28732, 0, 1, 36, 0, 0, 0, 0, 0, 0, 0, '', '');
+
 -- Doom Touched Warrior
 UPDATE `creature_template` SET `speed_walk` = 1.0, `speed_run` = 1.42857, `DamageModifier` = 17.1, `ArmorModifier` = 1.15, `RangeAttackTime` = 1265 WHERE `entry`=16157;
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- add spell to worshipper while mind controlled
- set condition for the spell to trigger on naxx40 version of Faerlina

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
Naxxramas worshippers did not have the Widow's Embrace spell
Faerlina was never effected by Widow's Embrace.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested this with individual progression
- Faerlina now gets hit by the spell when a worshipper dies normally near her and when a worshipper uses widows embrace while mind controlled.

