### PR TITLE
disable talk between dead Kel'Thuzad and the Lich King

### DIFF
--- a/src/Naxxramas/scripts/instance_naxxramas.cpp
+++ b/src/Naxxramas/scripts/instance_naxxramas.cpp
@@ -697,7 +697,7 @@ public:
             case EVENT_KELTHUZAD_LICH_KING_TALK1:
             {
                 if (GetBossState(BOSS_KELTHUZAD) == DONE)
-					break;
+                    break;
 
                 CreatureTalk(DATA_KELTHUZAD_BOSS, SAY_SAPP_DIALOG1);
                 return _events.ScheduleEvent(EVENT_KELTHUZAD_LICH_KING_TALK2, 10s);

--- a/src/Naxxramas/scripts/instance_naxxramas.cpp
+++ b/src/Naxxramas/scripts/instance_naxxramas.cpp
@@ -695,8 +695,13 @@ public:
                 SetGoState(DATA_SAPPHIRON_GATE, GO_STATE_ACTIVE);
                 return _events.ScheduleEvent(EVENT_KELTHUZAD_LICH_KING_TALK1, 5s);
             case EVENT_KELTHUZAD_LICH_KING_TALK1:
+            {
+                if (GetBossState(BOSS_KELTHUZAD) == DONE)
+					break;
+
                 CreatureTalk(DATA_KELTHUZAD_BOSS, SAY_SAPP_DIALOG1);
                 return _events.ScheduleEvent(EVENT_KELTHUZAD_LICH_KING_TALK2, 10s);
+            }
             case EVENT_KELTHUZAD_LICH_KING_TALK2:
                 CreatureTalk(DATA_LICH_KING_BOSS, SAY_SAPP_DIALOG2_LICH);
                 return _events.ScheduleEvent(EVENT_KELTHUZAD_LICH_KING_TALK3, 14s);

--- a/src/Naxxramas/scripts/instance_naxxramas.cpp
+++ b/src/Naxxramas/scripts/instance_naxxramas.cpp
@@ -667,7 +667,12 @@ public:
                 _horsemanAchievement = false;
                 break;
             case EVENT_KELTHUZAD_WING_TAUNT:
+            {
+                if (GetBossState(BOSS_KELTHUZAD) == DONE)
+                    break;
+
                 return CreatureTalk(DATA_KELTHUZAD_BOSS, _currentWingTaunt++);
+            }
             case EVENT_HORSEMEN_INTRO1:
                 CreatureTalk(DATA_THANE_KORTHAZZ_BOSS, SAY_HORSEMEN_DIALOG1);
                 return _events.ScheduleEvent(EVENT_HORSEMEN_INTRO2, 4500ms);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- no conversation between Kel'Thuzad and the Lich King if Kel'Thuzad has already been killed

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- compiles without errors
- test done in game with Individual Progression

Used same code style as was used for THADDIUS_SCREAMS
Only stopping first event, but it's a chain of events, so it stops them all.
