### PR TITLE
fix: entrance issues, group raid difficulty

### DIFF
--- a/data/sql/db-world/base/naxx40_creatures.sql
+++ b/data/sql/db-world/base/naxx40_creatures.sql
@@ -5651,7 +5651,7 @@ INSERT INTO `creature_model_info` (`DisplayID`, `BoundingRadius`, `CombatReach`,
 (16608, 0.3672, 1.8, 0, 0),
 (16609, 0, 0, 0, 0);
 
-DELETE FROM `creature_template_resistance` WHERE `CreatureID` IN (16157, 16158, 16448, 16449, 16451, 16452, 16453, 16861,
+DELETE FROM `creature_template_resistance` WHERE `CreatureID` IN (
 @CENTRY+0,  @CENTRY+1,  @CENTRY+2,  @CENTRY+3,  @CENTRY+4,  @CENTRY+5,  @CENTRY+6,  @CENTRY+7,  @CENTRY+8,  @CENTRY+9,  @CENTRY+10, @CENTRY+11, @CENTRY+12,
 @CENTRY+13, @CENTRY+14, @CENTRY+15, @CENTRY+16, @CENTRY+17, @CENTRY+18, @CENTRY+19, @CENTRY+20, @CENTRY+21, @CENTRY+22, @CENTRY+23, @CENTRY+24, @CENTRY+27,
 @CENTRY+28, @CENTRY+29, @CENTRY+30, @CENTRY+35, @CENTRY+36, @CENTRY+37, @CENTRY+38, @CENTRY+39, @CENTRY+40, @CENTRY+41, @CENTRY+44, @CENTRY+45, @CENTRY+48,
@@ -5659,14 +5659,6 @@ DELETE FROM `creature_template_resistance` WHERE `CreatureID` IN (16157, 16158, 
 @CENTRY+62, @CENTRY+63, @CENTRY+64, @CENTRY+65, @CENTRY+68, @CENTRY+70, @CENTRY+77, @CENTRY+78, @CENTRY+80, @CENTRY+82, @CENTRY+85, @CENTRY+86, @CENTRY+87, @CENTRY+91);
 
 INSERT INTO `creature_template_resistance` (`Resistance`, `CreatureID`, `School`) VALUES
-(5,    16448,       2), (5,    16448,       3), (5,    16448,       4), (5,    16448,       5), (5,    16448,       6),
-(5,    16449,       2), (5,    16449,       3), (5,    16449,       4), (5,    16449,       5), (5,    16449,       6),
-(10,   16451,       2), (10,   16451,       3), (10,   16451,       4), (10,   16451,       5), (10,   16451,       6),
-(10,   16452,       2), (10,   16452,       3), (10,   16452,       4), (10,   16452,       5), (10,   16452,       6),
-(5,    16453,       2), (5,    16453,       3), (5,    16453,       4), (5,    16453,       5), (5,    16453,       6),
-(5,    16157,       2), (5,    16157,       3), (5,    16157,       4), (5,    16157,       5), (5,    16157,       6),
-(5,    16158,       2), (5,    16158,       3), (5,    16158,       4), (5,    16158,       5), (5,    16158,       6),
-(5,    16861,       2), (5,    16861,       3), (5,    16861,       4), (5,    16861,       5), (5,    16861,       6),
 (15,   @CENTRY+0,   2), (15,   @CENTRY+0,   3), (15,   @CENTRY+0,   4), (15,   @CENTRY+0,   5), (15,   @CENTRY+0,   6),
 (15,   @CENTRY+1,   2), (15,   @CENTRY+1,   3), (15,   @CENTRY+1,   4), (15,   @CENTRY+1,   5), (15,   @CENTRY+1,   6),
 (15,   @CENTRY+2,   2), (15,   @CENTRY+2,   3), (15,   @CENTRY+2,   4), (15,   @CENTRY+2,   5), (15,   @CENTRY+2,   6),

--- a/data/sql/db-world/base/naxx40_creatures.sql
+++ b/data/sql/db-world/base/naxx40_creatures.sql
@@ -5810,7 +5810,7 @@ SET ci.`MechanicsMask` = ci.`MechanicsMask` | 6
 WHERE ct.`entry` IN (@CENTRY+54, 16158);
 
 -- Kel'Thuzad, Disable combat/assistance for creatures in the alcoves
-UPDATE `creature_template` SET `unit_flags` = 768 WHERE `entry` IN (@CENTRY+73, @CENTRY+74, @CENTRY+75);
+UPDATE `creature_template` SET `unit_flags` = 512 WHERE `entry` IN (@CENTRY+73, @CENTRY+74, @CENTRY+75);
 
 -- Deathknight Understudy, add spells while mind controlled, taunt and bone barrier
 DELETE FROM `creature_template_spell` WHERE (`CreatureID` = @CENTRY+84);

--- a/src/Naxxramas/scripts/custom_creatures_40.cpp
+++ b/src/Naxxramas/scripts/custom_creatures_40.cpp
@@ -37,7 +37,12 @@ public:
                 {
                     if (isAttuned(player))
                     {
-                        player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                        Group* group = player->GetGroup();
+                        if (group)
+                            group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+                        else
+                            player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+
                         player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
                     }
                 }

--- a/src/Naxxramas/scripts/custom_gameobjects_40.cpp
+++ b/src/Naxxramas/scripts/custom_gameobjects_40.cpp
@@ -55,7 +55,12 @@ public:
             return true;
         }
 
-        player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+        Group* group = player->GetGroup();
+        if (group)
+            group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+        else
+            player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_HEROIC);
+
         player->TeleportTo(533, 3005.51f, -3434.64f, 304.195f, 6.2831f);
 
         return true;

--- a/src/Naxxramas/scripts/custom_scripts_40.cpp
+++ b/src/Naxxramas/scripts/custom_scripts_40.cpp
@@ -31,7 +31,11 @@ public:
         Difficulty diff = player->GetGroup() ? player->GetGroup()->GetDifficulty(true) : player->GetDifficulty(true);
         if (diff == RAID_DIFFICULTY_10MAN_HEROIC)
         {
-            player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_NORMAL);
+            Group* group = player->GetGroup();
+            if (group)
+                group->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_NORMAL);
+            else
+                player->SetRaidDifficulty(RAID_DIFFICULTY_10MAN_NORMAL);
         }
         switch (areaTrigger->entry)
         {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

See
-  https://github.com/ZhengPeiRu21/mod-individual-progression/pull/1229

> even though raid difficulty was set to 10 man heroic for the player, it was not always done so for the group.
making it possible for the player to end up in the wotlk version of Onyxia/Naxxramas.

> now the raid difficulty for the group is also set to 10man heroic.

> credit and thank you to Crow for finding this
> and being able to show me how to reproduce it.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
